### PR TITLE
Add the YouTube URL for the mediator tutorial

### DIFF
--- a/0_Starting_OpenHIM.md
+++ b/0_Starting_OpenHIM.md
@@ -2,7 +2,7 @@
 
 ## **OpenHIM SetUp Tutorial**
 
-**TLDR; Watch Linux Tutorial Setup on [YouTube](https://www.youtube.com/watch?v=)**
+**TLDR; Watch Linux Tutorial Setup on [YouTube](https://www.youtube.com/watch?v=DUr_mBWIVXk)**
 
 ## Useful Links
 


### PR DESCRIPTION
The YouTube link to the video tutorial wasnt correct. This now points to the a valid YouTube video for the mediator tutorial